### PR TITLE
Set namespace to `index-observer` uniformply across K8S manifests

### DIFF
--- a/deploy/manifests/base/service.yaml
+++ b/deploy/manifests/base/service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: index-observer
   name: index-observer
+  namespace: index-observer
 spec:
   clusterIP: None
   ports:

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: index-observer
+
 resources:
   - ../../base
   - monitor.yaml


### PR DESCRIPTION
Set the K8S namespace explictly in base K8S manifests and override it to
`index-observer` in `dev` overlay kustomization to assert that namespace
shold be uniformly set across all resources in that overlay.