### PR TITLE
Limit resources occupied by index observer

### DIFF
--- a/deploy/manifests/dev/us-east-2/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/patch.yaml
@@ -10,6 +10,9 @@ spec:
         - name: index-observer
           image: index-observer
           resources:
+            limits:
+              cpu: "3.5"
+              memory: 10Gi
             requests:
               cpu: "3.5"
               memory: 10Gi


### PR DESCRIPTION
Set a limit to the resources occupied by index observer to avoid excessive resource consumptions which results in healthcheck failure for other containers scheduled on the same node.