### PR TITLE
Add context timeouts and a few smaller things

### DIFF
--- a/progress_observer/metrics/metrics.go
+++ b/progress_observer/metrics/metrics.go
@@ -42,7 +42,7 @@ const (
 func aggregationSelector(ik metric.InstrumentKind) aggregation.Aggregation {
 	if ik == metric.InstrumentKindHistogram {
 		return aggregation.ExplicitBucketHistogram{
-			Boundaries: []float64{0, 1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 1000, 2000, 5000},
+			Boundaries: []float64{0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000},
 			NoMinMax:   false,
 		}
 	}

--- a/progress_observer/metrics/metrics.go
+++ b/progress_observer/metrics/metrics.go
@@ -107,7 +107,12 @@ func (m *Metrics) observe(ctx context.Context, observer cmetric.Observer) error 
 	defer m.countObservationsLock.Unlock()
 
 	for _, o := range m.countObservations {
-		observer.ObserveInt64(m.count, int64(o.count), attribute.String("source", o.source), attribute.String("target", o.target), attribute.String("kind", o.kind))
+		tags := []attribute.KeyValue{attribute.String("source", o.source), attribute.String("kind", o.kind)}
+		if len(o.target) > 0 {
+			tags = append(tags, attribute.String("target", o.target))
+		}
+
+		observer.ObserveInt64(m.count, int64(o.count), tags...)
 	}
 
 	m.countObservations = make([]countObservation, 0)

--- a/progress_observer/progress_observer.go
+++ b/progress_observer/progress_observer.go
@@ -43,7 +43,7 @@ func (s *progressInfo) String() string {
 	return fmt.Sprintf("peer: %s, lag: %d, unreachable: %v", s.source.AddrInfo.ID.String(), s.lag, s.unreachable)
 }
 
-func ObserveIndexers(ctx context.Context, sourceUrl, targetUrl string, m *metrics.Metrics) error {
+func ObserveIndexers(ctx context.Context, sourceUrl, targetUrl string, m *metrics.Metrics, reportLags bool) error {
 	sourceName, err := extractDomain(sourceUrl)
 	if err != nil {
 		return err
@@ -119,6 +119,10 @@ func ObserveIndexers(ctx context.Context, sourceUrl, targetUrl string, m *metric
 	m.RecordCount(len(matches), sourceName, targetName, metrics.MatchCount)
 	m.RecordCount(len(unknwonByTarget), sourceName, targetName, metrics.UnknownCount)
 	m.RecordCount(len(unknownBySource), targetName, sourceName, metrics.UnknownCount)
+
+	if !reportLags {
+		return nil
+	}
 
 	numJobs := len(mismatches)
 

--- a/progress_observer/progress_observer.go
+++ b/progress_observer/progress_observer.go
@@ -265,10 +265,8 @@ func findLag(ctx context.Context, addr peer.AddrInfo, scid, tcid cid.Cid) (int, 
 			}
 			iter++
 			if shead == cid.Undef && thead == cid.Undef {
-				break
+				return 0, errors.New("could not find neither target or source cids")
 			}
 		}
 	}
-
-	return 0, errors.New("could not find neither target or source cids")
 }

--- a/task/task.go
+++ b/task/task.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	countsObserveFreq = 10 * time.Minute
-	lagsObserveFreq   = 30 * time.Minute
+	lagsObserveFreq   = 20 * time.Minute
 	timerFreq         = 10 * time.Minute
 )
 

--- a/task/task.go
+++ b/task/task.go
@@ -20,7 +20,8 @@ const (
 var log = logging.Logger("task")
 
 func Start(c *cli.Context) error {
-	logging.SetLogLevel("*", "info")
+	logging.SetLogLevel("*", "warn")
+	logging.SetLogLevel("progress_observer", "info")
 
 	if err := StartMetrics(c); err != nil {
 		return err


### PR DESCRIPTION
* Add context timeouts as fetching some chains takes a while
* Report lags as they come in instead of waiting for all  jobs to finish
* Adjust histogram buckets to more reasonable values
* Refresh metrics every 10 minutes
* Separate lags and counts reporting from separate goroutines as latter requires much longer than former to complete
* time limit how long syncing ads can take