### PR TITLE
Fix progress observer bug with incorrect error handling

### DIFF
--- a/progress_observer/progress_observer.go
+++ b/progress_observer/progress_observer.go
@@ -58,25 +58,25 @@ func ObserveIndexers(ctx context.Context, sourceUrl, targetUrl string, m *metric
 	// create clients
 	sourceClient, err := finderhttpclient.New(sourceUrl)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	targetClient, err := finderhttpclient.New(targetUrl)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// fetch source and target providers
 	sources, err := sourceClient.ListProviders(ctx)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	m.RecordCount(len(sources), sourceName, "", metrics.TotalCount)
 
 	targets, err := targetClient.ListProviders(ctx)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	m.RecordCount(len(targets), targetName, "", metrics.TotalCount)


### PR DESCRIPTION
The bug caused index-observer to crash when any of the indexers it's observing were unavailable